### PR TITLE
PP-7788: Delete .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: node_js
-node_js:
-    - 12.17.0


### PR DESCRIPTION
## WHAT
We are deprecating use of Travis CI.

## HOW 
CI doesn't rely on travis CI anymore


